### PR TITLE
[codex] Unify Atlas mobile mention touch selection

### DIFF
--- a/src/view/components/Aura.test.ts
+++ b/src/view/components/Aura.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { IMPORTANT_GLOW, calculateGlowStyles, scanNodeForTags } from './Aura'
-import { fetchHashtags } from '../content/HashtagMention'
+import { fetchHashtags, getHashtagRenderAttributes } from '../content/HashtagMention'
 
 type FakeNode = {
   type: { name: string }
@@ -38,6 +38,23 @@ describe('fetchHashtags', () => {
     const matches = fetchHashtags('act')
 
     expect(matches.some((tag) => tag.id === 'tag:active' && tag.label === 'active')).toBe(true)
+  })
+
+  test('renders hashtag nodes as draggable chips with a focus glow', () => {
+    const attrs = getHashtagRenderAttributes({
+      id: 'tag:focus',
+      label: '☀️ focus',
+      'data-tag': 'focus',
+      'data-color': '#ffb700',
+    })
+
+    expect(attrs.draggable).toBe('true')
+    expect(attrs['data-hashtag-draggable']).toBe('true')
+    expect(attrs['data-drag-handle']).toBe('')
+    expect(attrs.contenteditable).toBe('false')
+    expect(attrs.class).toContain('atomic-mention')
+    expect(attrs.class).toContain('hashtag-mention')
+    expect(attrs.class).toContain('focus-glow')
   })
 })
 

--- a/src/view/content/AuraMention.tsx
+++ b/src/view/content/AuraMention.tsx
@@ -3,12 +3,17 @@
 import './MentionList.scss'
 import { Extension, mergeAttributes } from '@tiptap/core'
 import { Node } from '@tiptap/core'
-import { ReactRenderer } from '@tiptap/react'
+import { NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer, ReactRenderer } from '@tiptap/react'
 import Suggestion, { SuggestionKeyDownProps, SuggestionOptions, SuggestionProps } from '@tiptap/suggestion'
 import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react'
 import tippy, { Instance as TippyInstance } from 'tippy.js'
 import { motion } from 'framer-motion'
 import { PluginKey } from '@tiptap/pm/state'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 // Unique plugin key to avoid conflicts with other extensions
 const AuraPluginKey = new PluginKey('aura-suggestion')
@@ -156,12 +161,56 @@ AuraList.displayName = 'AuraList'
 // Aura Node (for rendering inserted aura mentions)
 // ============================================================================
 
+const getAuraGlowStyle = (auraId: string) => {
+  if (auraId?.includes('humility-level-4') || auraId?.includes('higher-energy')) {
+    return '0 0 12px 3px rgba(255, 240, 50, 0.6), 0 0 25px 6px rgba(255, 250, 100, 0.35)'
+  }
+  if (auraId?.includes('gratitude-level-3') || auraId?.includes('semi-higher-energy')) {
+    return '0 0 10px 3px rgba(255, 252, 230, 0.6), 0 0 20px 5px rgba(250, 248, 220, 0.35)'
+  }
+  if (auraId?.includes('respect-level-2')) {
+    return '0 0 8px 2px rgba(255, 255, 255, 0.8), 0 0 18px 4px rgba(245, 245, 245, 0.5)'
+  }
+  if (auraId?.includes('energy-level-1') || auraId?.includes('semi-lower-energy')) {
+    return '0 0 10px 3px rgba(0, 0, 0, 0.2), 0 0 20px 5px rgba(0, 0, 0, 0.12)'
+  }
+  if (auraId?.includes('lower-energy')) {
+    return '0 0 12px 3px rgba(0, 0, 0, 0.3), 0 0 25px 6px rgba(0, 0, 0, 0.18)'
+  }
+  if (auraId?.includes('blockage')) {
+    return '0 0 12px 3px rgba(0, 0, 0, 0.65), 0 0 28px 8px rgba(0, 0, 0, 0.4)'
+  }
+  return ''
+}
+
+const AuraNodeView = ({ node, selected, editor, getPos }: NodeViewProps) => {
+  const auraId = String(node.attrs.id ?? '')
+  const glowStyle = getAuraGlowStyle(auraId)
+  const { mentionInteractionProps, handleMentionClick } =
+    useMentionNodeInteraction({ editor, getPos })
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      {...mentionInteractionProps}
+      className={withMentionInteractionClass(`timepoint-mention ${selected ? 'selected' : ''}`)}
+      data-type={AURA_DATA_TYPE}
+      data-id={node.attrs.id || undefined}
+      style={glowStyle ? { boxShadow: glowStyle, borderRadius: 4 } : undefined}
+      onClick={handleMentionClick}
+    >
+      {node.attrs.label || ''}
+    </NodeViewWrapper>
+  )
+}
+
 export const AuraNode = Node.create({
   name: AURA_NODE_NAME,
   group: 'inline',
   inline: true,
   selectable: true,
   atom: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -179,39 +228,22 @@ export const AuraNode = Node.create({
 
   renderHTML({ node, HTMLAttributes }) {
     const auraId = node.attrs.id as string
-    
-    // Determine glow based on energy level
-    let glowStyle = ''
-    if (auraId?.includes('humility-level-4') || auraId?.includes('higher-energy')) {
-      // Strong Yang - bright yellow sun glow
-      glowStyle = '0 0 12px 3px rgba(255, 240, 50, 0.6), 0 0 25px 6px rgba(255, 250, 100, 0.35)'
-    } else if (auraId?.includes('gratitude-level-3') || auraId?.includes('semi-higher-energy')) {
-      // Gratitude / Lesser Yang - pale white-yellow glow
-      glowStyle = '0 0 10px 3px rgba(255, 252, 230, 0.6), 0 0 20px 5px rgba(250, 248, 220, 0.35)'
-    } else if (auraId?.includes('respect-level-2')) {
-      // Respect - soft white ring aura
-      glowStyle = '0 0 8px 2px rgba(255, 255, 255, 0.8), 0 0 18px 4px rgba(245, 245, 245, 0.5)'
-    } else if (auraId?.includes('energy-level-1') || auraId?.includes('semi-lower-energy')) {
-      // Level 1 / Lesser Yin - soft dark shadow
-      glowStyle = '0 0 10px 3px rgba(0, 0, 0, 0.2), 0 0 20px 5px rgba(0, 0, 0, 0.12)'
-    } else if (auraId?.includes('lower-energy')) {
-      // Strong Yin - deeper dark shadow
-      glowStyle = '0 0 12px 3px rgba(0, 0, 0, 0.3), 0 0 25px 6px rgba(0, 0, 0, 0.18)'
-    } else if (auraId?.includes('blockage')) {
-      // Blockage - black aura, distinct from higher yang energies
-      glowStyle = '0 0 12px 3px rgba(0, 0, 0, 0.65), 0 0 28px 8px rgba(0, 0, 0, 0.4)'
-    }
+    const glowStyle = getAuraGlowStyle(auraId)
     
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: 'timepoint-mention',
         'data-type': AURA_DATA_TYPE,
         'data-id': node.attrs.id,
         style: glowStyle ? `box-shadow: ${glowStyle}; border-radius: 4px;` : '',
-      }),
+      })),
       node.attrs.label || '',
     ]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(AuraNodeView)
   },
 })
 

--- a/src/view/content/CommentMention.tsx
+++ b/src/view/content/CommentMention.tsx
@@ -9,6 +9,11 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import { motion } from 'framer-motion'
 import { NodeSelection } from 'prosemirror-state'
 import type { Editor } from '@tiptap/core'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 export interface CommentMentionAttributes {
   text: string
@@ -108,6 +113,7 @@ const CommentMentionNodeView = ({
   const isExpanded = isEditing || selected
   const displayText = text.trim() || 'Type a comment'
   const inputWidth = `${Math.min(Math.max(editValue.length + 2, 14), 62)}ch`
+  const { mentionInteractionProps, selectNode } = useMentionNodeInteraction({ editor, getPos })
 
   const focusCommentInput = useCallback(() => {
     const input = inputRef.current
@@ -145,16 +151,6 @@ const CommentMentionNodeView = ({
       setEditValue(text)
     }
   }, [text, isEditing])
-
-  const selectNode = useCallback(() => {
-    try {
-      const pos = getPos()
-      if (typeof pos !== 'number') return
-      editor.chain().focus().setNodeSelection(pos).run()
-    } catch {
-      // Ignore stale positions while the document is mutating.
-    }
-  }, [editor, getPos])
 
   const removeNode = useCallback(() => {
     try {
@@ -222,12 +218,13 @@ const CommentMentionNodeView = ({
   return (
     <NodeViewWrapper
       as="span"
-      className={[
+      {...mentionInteractionProps}
+      className={withMentionInteractionClass([
         'question-mention',
         'comment-mention',
         isExpanded ? 'comment-mention-expanded' : 'comment-mention-collapsed',
         selected ? 'selected' : '',
-      ].filter(Boolean).join(' ')}
+      ].filter(Boolean).join(' '))}
       data-type="comment-mention"
       data-comment-id={commentId ?? undefined}
       data-comment-anchor={anchorText || undefined}
@@ -244,7 +241,7 @@ const CommentMentionNodeView = ({
           duration: 0.16,
           ease: 'easeOut',
         }}
-        onPointerDown={!isEditing ? beginEditing : undefined}
+        onClick={!isEditing ? beginEditing : undefined}
       >
         <span className="question-checkbox comment-mention-icon" contentEditable={false}>
           <span className="question-checkbox-icon" aria-hidden="true">💬</span>
@@ -261,6 +258,7 @@ const CommentMentionNodeView = ({
             onBlur={handleInputBlur}
             placeholder={anchorText ? `Comment on "${anchorText}"` : 'Type a comment'}
             style={{ width: inputWidth }}
+            data-mention-interaction-ignore="true"
             onClick={(event) => event.stopPropagation()}
             onPointerDown={(event) => event.stopPropagation()}
             onMouseDown={(event) => event.stopPropagation()}
@@ -288,6 +286,7 @@ export const CommentMentionNode = Node.create({
   inline: true,
   atom: true,
   selectable: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -332,13 +331,13 @@ export const CommentMentionNode = Node.create({
 
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: 'question-mention comment-mention comment-mention-collapsed',
         'data-type': 'comment-mention',
         'data-comment-text': text,
         ...(anchorText ? { 'data-comment-anchor': anchorText } : {}),
         ...(commentId ? { 'data-comment-id': commentId } : {}),
-      }),
+      })),
       `💬 ${buildCollapsedLabel(text)}`,
     ]
   },

--- a/src/view/content/DurationMention.tsx
+++ b/src/view/content/DurationMention.tsx
@@ -3,10 +3,15 @@
 import './MentionList.scss'
 import React, { useState, useEffect, forwardRef, useImperativeHandle, useCallback } from 'react'
 import { Extension, Node, mergeAttributes } from '@tiptap/core'
-import { ReactRenderer, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import { ReactRenderer, NodeViewWrapper, ReactNodeViewRenderer, NodeViewProps } from '@tiptap/react'
 import Suggestion, { SuggestionProps, SuggestionKeyDownProps } from '@tiptap/suggestion'
 import tippy, { Instance as TippyInstance } from 'tippy.js'
 import { PluginKey } from 'prosemirror-state'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 // ============================================================================
 // Duration Badge Node (for durations that should NOT use Pomodoro)
@@ -14,29 +19,23 @@ import { PluginKey } from 'prosemirror-state'
 // that shouldn't be treated as single-session timers.
 // ============================================================================
 
-interface DurationBadgeNodeViewProps {
-  node: {
-    attrs: {
-      duration: number
-      label: string
-      emoji: string
-      id: string
-    }
-  }
-  selected: boolean
-}
-
-const DurationBadgeNodeView: React.FC<DurationBadgeNodeViewProps> = ({
+const DurationBadgeNodeView: React.FC<NodeViewProps> = ({
   node,
   selected,
+  editor,
+  getPos,
 }) => {
   const { label, emoji } = node.attrs
+  const { mentionInteractionProps, handleMentionClick } =
+    useMentionNodeInteraction({ editor, getPos })
 
   return (
     <NodeViewWrapper
       as="span"
-      className={`duration-badge ${selected ? 'selected' : ''}`}
+      {...mentionInteractionProps}
+      className={withMentionInteractionClass(`duration-badge ${selected ? 'selected' : ''}`)}
       data-id={node.attrs.id}
+      onClick={handleMentionClick}
     >
       <span className="duration-badge-emoji">{emoji}</span>
       <span className="duration-badge-label">{label}</span>
@@ -73,6 +72,8 @@ export const DurationBadgeNode = Node.create<DurationBadgeOptions>({
   selectable: true,
 
   atom: true,
+
+  draggable: true,
 
   addOptions() {
     return {
@@ -126,7 +127,7 @@ export const DurationBadgeNode = Node.create<DurationBadgeOptions>({
     return ['span', mergeAttributes(
       this.options.HTMLAttributes,
       HTMLAttributes,
-      { 'data-type': 'duration-badge' }
+      getMentionRenderAttributes({ class: 'duration-badge', 'data-type': 'duration-badge' })
     ), `${emoji} ${label}`]
   },
 

--- a/src/view/content/HashtagMention.tsx
+++ b/src/view/content/HashtagMention.tsx
@@ -3,13 +3,18 @@
 import './MentionList.scss'
 import { Extension, mergeAttributes, nodeInputRule } from '@tiptap/core'
 import { Node } from '@tiptap/core'
-import { ReactRenderer } from '@tiptap/react'
+import { NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer, ReactRenderer } from '@tiptap/react'
 import Suggestion, { SuggestionKeyDownProps, SuggestionOptions, SuggestionProps } from '@tiptap/suggestion'
 import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react'
 import tippy, { Instance as TippyInstance } from 'tippy.js'
 import { motion } from 'framer-motion'
 import { PluginKey } from '@tiptap/pm/state'
 import { AuraSpec, toAuraDataAttributes } from '../aura/AuraModel'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 // Unique plugin key to avoid conflicts with other extensions
 const HashtagPluginKey = new PluginKey('hashtag-suggestion')
@@ -322,12 +327,114 @@ HashtagList.displayName = 'HashtagList'
 // Hashtag Node (for rendering inserted hashtags)
 // ============================================================================
 
+type HashtagNodeAttrs = Record<string, unknown>
+
+const getHashtagExtraClass = (attrs: HashtagNodeAttrs) => {
+  const label = String(attrs.label ?? '')
+  const dataTag = String(attrs['data-tag'] ?? '')
+  const id = String(attrs.id ?? '')
+
+  if (
+    label.includes('⭐️ important') ||
+    label === 'important' ||
+    dataTag === 'important' ||
+    dataTag === 'active' ||
+    id === 'tag:active' ||
+    label === 'active' ||
+    label === '#active'
+  ) {
+    return ' glow'
+  }
+
+  if (label.includes('✅ complete') || label === 'complete' || dataTag === 'complete') {
+    return ' green-glow'
+  }
+
+  if (label.includes('☀️ focus') || label === 'focus' || dataTag === 'focus') {
+    return ' focus-glow'
+  }
+
+  if (label.includes('not-a-priority') || dataTag === 'not-a-priority' || id === 'tag:not-a-priority') {
+    return ' dim-glow'
+  }
+
+  return ''
+}
+
+const optionalDataAttribute = (attrs: HashtagNodeAttrs, name: string) => {
+  const value = attrs[name]
+  return value == null || value === '' ? {} : { [name]: value }
+}
+
+const reactDataAttributeValue = (value: unknown) => {
+  if (value == null || value === '') return undefined
+  return String(value)
+}
+
+export const getHashtagRenderAttributes = (
+  attrs: HashtagNodeAttrs,
+  HTMLAttributes: Record<string, unknown> = {},
+) => mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
+  class: `hashtag-mention${getHashtagExtraClass(attrs)}`,
+  'data-type': 'hashtag',
+  'data-id': attrs.id,
+  'data-hashtag-draggable': 'true',
+  ...optionalDataAttribute(attrs, 'data-color'),
+  ...optionalDataAttribute(attrs, 'data-aura-color'),
+  ...optionalDataAttribute(attrs, 'data-aura-luminance'),
+  ...optionalDataAttribute(attrs, 'data-aura-size'),
+}))
+
+const HashtagNodeView = ({ node, selected, editor, getPos }: NodeViewProps) => {
+  const attrs = node.attrs as HashtagNodeAttrs
+  const className = withMentionInteractionClass(
+    `hashtag-mention${getHashtagExtraClass(attrs)}${selected ? ' selected' : ''}`,
+  )
+  const {
+    mentionInteractionProps,
+    handleMentionClick,
+    handleMentionPointerDown,
+  } = useMentionNodeInteraction({ editor, getPos })
+
+  return (
+    <NodeViewWrapper as="span" style={{ display: 'inline', position: 'relative' }}>
+      <span
+        {...mentionInteractionProps}
+        className={className}
+        data-type="hashtag"
+        data-id={reactDataAttributeValue(attrs.id)}
+        data-hashtag-draggable="true"
+        data-color={reactDataAttributeValue(attrs['data-color'])}
+        data-aura-color={reactDataAttributeValue(attrs['data-aura-color'])}
+        data-aura-luminance={reactDataAttributeValue(attrs['data-aura-luminance'])}
+        data-aura-size={reactDataAttributeValue(attrs['data-aura-size'])}
+        onClick={handleMentionClick}
+      >
+        <span
+          className="hashtag-grip"
+          contentEditable={false}
+          data-drag-handle
+          onPointerDown={handleMentionPointerDown}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          aria-label="Drag tag"
+          title="Drag tag"
+        />
+        {String(attrs.label ?? '')}
+      </span>
+    </NodeViewWrapper>
+  )
+}
+
 export const HashtagNode = Node.create({
   name: 'hashtag',
   group: 'inline',
   inline: true,
   selectable: true,
   atom: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -346,39 +453,16 @@ export const HashtagNode = Node.create({
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    // Add special glow classes for important, complete, and focus tags
-    // These work with the Aura component for visual effects
-    const label = (node.attrs.label as string) || ''
-    const dataTag = (node.attrs['data-tag'] as string) || ''
-    const id = (node.attrs.id as string) || ''
-    let extraClass = ''
-    if (
-      label.includes('⭐️ important') ||
-      label === 'important' ||
-      dataTag === 'important' ||
-      dataTag === 'active' ||
-      id === 'tag:active' ||
-      label === 'active' ||
-      label === '#active'
-    ) {
-      extraClass = ' glow'
-    } else if (label.includes('✅ complete') || label === 'complete' || dataTag === 'complete') {
-      extraClass = ' green-glow'
-    } else if (label.includes('☀️ focus') || label === 'focus' || dataTag === 'focus') {
-      extraClass = ' focus-glow'
-    } else if (label.includes('not-a-priority') || dataTag === 'not-a-priority' || id === 'tag:not-a-priority') {
-      extraClass = ' dim-glow'
-    }
-
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
-        class: 'hashtag-mention' + extraClass,
-        'data-type': 'hashtag',
-        'data-id': node.attrs.id,
-      }),
-      label,
+      getHashtagRenderAttributes(node.attrs, HTMLAttributes),
+      ['span', { class: 'hashtag-grip', contenteditable: 'false', 'data-drag-handle': '' }],
+      node.attrs.label || '',
     ]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(HashtagNodeView)
   },
 
   // Quick input rules for common tags

--- a/src/view/content/LocationMention.tsx
+++ b/src/view/content/LocationMention.tsx
@@ -12,6 +12,11 @@ import { PluginKey } from '@tiptap/pm/state'
 import mapboxgl from 'mapbox-gl'
 import { deferNodeViewAttributeUpdate } from './deferNodeViewAttributeUpdate'
 import { shouldSuppressLocationTagMapPopup } from './MapboxMapShared'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 // Unique plugin key to avoid conflicts with other extensions
 const LocationPluginKey = new PluginKey('location-suggestion')
@@ -525,6 +530,8 @@ const LocationNodeView = ({ node, selected, updateAttributes, editor, getPos }: 
   const tagRef = useRef<HTMLSpanElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   const [popoverPosition, setPopoverPosition] = useState({ top: 0, left: 0 })
+  const { mentionInteractionProps, handleMentionPointerDown } =
+    useMentionNodeInteraction({ editor, getPos })
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -561,18 +568,6 @@ const LocationNodeView = ({ node, selected, updateAttributes, editor, getPos }: 
     setIsExpanded(false)
   }
 
-  const handleGripMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    try {
-      const pos = getPos()
-      if (typeof pos !== 'number') return
-      editor.chain().focus().setNodeSelection(pos).run()
-    } catch {
-      // Ignore stale positions when the node is being removed.
-    }
-  }, [editor, getPos])
-
   // Close popover when clicking outside
   useEffect(() => {
     if (!isExpanded) return
@@ -603,8 +598,9 @@ const LocationNodeView = ({ node, selected, updateAttributes, editor, getPos }: 
   return (
     <NodeViewWrapper as="span" style={{ display: 'inline', position: 'relative' }}>
       <span
+        {...mentionInteractionProps}
         ref={tagRef}
-        className={`location-mention ${selected ? 'selected' : ''}`}
+        className={withMentionInteractionClass(`location-mention ${selected ? 'selected' : ''}`)}
         data-location-id={attrs.id || undefined}
         data-location-connection-id={locationConnectionId || undefined}
         data-location-label={label || undefined}
@@ -612,13 +608,12 @@ const LocationNodeView = ({ node, selected, updateAttributes, editor, getPos }: 
         data-location-country={attrs['data-country'] || undefined}
         data-location-coords={coordsStr || undefined}
         onClick={handleClick}
-        style={{ cursor: 'pointer' }}
       >
         <span
           className="location-grip"
           contentEditable={false}
           data-drag-handle
-          onMouseDown={handleGripMouseDown}
+          onPointerDown={handleMentionPointerDown}
           onClick={(e) => {
             e.preventDefault()
             e.stopPropagation()
@@ -722,6 +717,7 @@ export const LocationNode = Node.create({
   inline: true,
   selectable: true,
   atom: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -752,12 +748,12 @@ export const LocationNode = Node.create({
   renderHTML({ node, HTMLAttributes }) {
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: 'location-mention',
         'data-type': 'location',
         'data-id': node.attrs.id,
         'data-location-connection-id': node.attrs.locationId,
-      }),
+      })),
       node.attrs.label || '',
     ]
   },

--- a/src/view/content/Mention.tsx
+++ b/src/view/content/Mention.tsx
@@ -3,6 +3,7 @@ import './styles.scss';
 import { Mention, MentionOptions } from '@tiptap/extension-mention';
 import { Node as ProsemirrorNode } from 'prosemirror-model';
 import { mergeAttributes, nodeInputRule } from '@tiptap/core';
+import { getMentionRenderAttributes } from './MentionInteraction'
 
 export const CustomMention = Mention.extend({
   addOptions(): MentionOptions {
@@ -26,11 +27,11 @@ export const CustomMention = Mention.extend({
 
     return [
       'span',
-      mergeAttributes(HTMLAttributes, { 
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: classes,
         'data-type': 'mention',
         'data-id': node.attrs.id || node.attrs.label
-      }),
+      })),
       `${node.attrs.label}`
     ]
   },

--- a/src/view/content/MentionInteraction.ts
+++ b/src/view/content/MentionInteraction.ts
@@ -1,0 +1,105 @@
+import type { Editor } from '@tiptap/core'
+import React, { useCallback } from 'react'
+
+const MENTION_INTERACTION_CLASS = 'atomic-mention'
+
+type MentionNodePositionGetter = () => number | undefined
+
+const isIgnoredInteractionTarget = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) return false
+
+  return Boolean(
+    target.closest(
+      'input, textarea, select, button, [contenteditable="true"], [data-mention-interaction-ignore="true"]',
+    ),
+  )
+}
+
+export const withMentionInteractionClass = (className = '') => {
+  const classes = className.split(/\s+/).filter(Boolean)
+  return classes.includes(MENTION_INTERACTION_CLASS)
+    ? classes.join(' ')
+    : [MENTION_INTERACTION_CLASS, ...classes].join(' ')
+}
+
+export const getMentionRenderAttributes = (attrs: Record<string, unknown> = {}) => ({
+  ...attrs,
+  class: withMentionInteractionClass(String(attrs.class ?? '')),
+  'data-mention-interaction': 'atomic',
+  'data-drag-handle': '',
+  contenteditable: 'false',
+  draggable: 'true',
+})
+
+export const selectMentionNode = (editor: Editor, getPos: MentionNodePositionGetter) => {
+  try {
+    const pos = getPos()
+    if (typeof pos !== 'number') return false
+    editor.chain().focus().setNodeSelection(pos).run()
+    return true
+  } catch {
+    return false
+  }
+}
+
+export const useMentionNodeInteraction = ({
+  editor,
+  getPos,
+}: {
+  editor: Editor
+  getPos: MentionNodePositionGetter
+}) => {
+  const selectNode = useCallback(
+    () => selectMentionNode(editor, getPos),
+    [editor, getPos],
+  )
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      if (isIgnoredInteractionTarget(event.target)) return
+      if (event.pointerType === 'mouse' && event.button !== 0) return
+      selectNode()
+    },
+    [selectNode],
+  )
+
+  const handleContextMenu = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (isIgnoredInteractionTarget(event.target)) return
+      event.preventDefault()
+      event.stopPropagation()
+      selectNode()
+    },
+    [selectNode],
+  )
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (isIgnoredInteractionTarget(event.target)) return
+      event.preventDefault()
+      event.stopPropagation()
+      selectNode()
+    },
+    [selectNode],
+  )
+
+  const handleDragStart = useCallback(() => {
+    selectNode()
+  }, [selectNode])
+
+  return {
+    selectNode,
+    mentionInteractionProps: {
+      contentEditable: false,
+      draggable: true,
+      'data-drag-handle': true,
+      'data-mention-interaction': 'atomic',
+      onPointerDown: handlePointerDown,
+      onContextMenu: handleContextMenu,
+      onDragStart: handleDragStart,
+    },
+    handleMentionClick: handleClick,
+    handleMentionContextMenu: handleContextMenu,
+    handleMentionPointerDown: handlePointerDown,
+  }
+}

--- a/src/view/content/MentionList.scss
+++ b/src/view/content/MentionList.scss
@@ -214,14 +214,52 @@
   box-shadow: 0px 0.36px 1.8px -1.67px rgba(0, 0, 0, 0.23), 
               0px 1.37px 6.87px -3.33px rgba(0, 0, 0, 0.19), 
               0px 6px 30px -5px rgba(0, 0, 0, 0);
-  cursor: pointer;
+  cursor: grab;
   vertical-align: middle;
   margin: 0 0.125rem;
   overflow: hidden;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
   
   &:hover {
     background-color: #f5f5f5;
     border-color: #999999;
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  &.selected {
+    outline: 2px solid rgba(99, 102, 241, 0.85);
+    outline-offset: 1px;
+  }
+}
+
+.hashtag-grip {
+  display: inline-block;
+  width: 8px;
+  height: 12px;
+  margin: 0;
+  vertical-align: middle;
+  cursor: grab;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='12' viewBox='0 0 8 12'%3E%3Ccircle cx='2' cy='2' r='1.2' fill='rgba(0,0,0,0.35)'/%3E%3Ccircle cx='6' cy='2' r='1.2' fill='rgba(0,0,0,0.35)'/%3E%3Ccircle cx='2' cy='6' r='1.2' fill='rgba(0,0,0,0.35)'/%3E%3Ccircle cx='6' cy='6' r='1.2' fill='rgba(0,0,0,0.35)'/%3E%3Ccircle cx='2' cy='10' r='1.2' fill='rgba(0,0,0,0.35)'/%3E%3Ccircle cx='6' cy='10' r='1.2' fill='rgba(0,0,0,0.35)'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  flex-shrink: 0;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  &:hover {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='12' viewBox='0 0 8 12'%3E%3Ccircle cx='2' cy='2' r='1.2' fill='rgba(0,0,0,0.6)'/%3E%3Ccircle cx='6' cy='2' r='1.2' fill='rgba(0,0,0,0.6)'/%3E%3Ccircle cx='2' cy='6' r='1.2' fill='rgba(0,0,0,0.6)'/%3E%3Ccircle cx='6' cy='6' r='1.2' fill='rgba(0,0,0,0.6)'/%3E%3Ccircle cx='2' cy='10' r='1.2' fill='rgba(0,0,0,0.6)'/%3E%3Ccircle cx='6' cy='10' r='1.2' fill='rgba(0,0,0,0.6)'/%3E%3C/svg%3E");
   }
 }
 
@@ -532,6 +570,35 @@
 .pomodoro-node.selected {
   outline: 2px solid #6366f1;
   outline-offset: 2px;
+}
+
+.atomic-mention.atomic-mention {
+  cursor: grab;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  &.selected {
+    outline: 2px solid #6366f1;
+    outline-offset: 1px;
+  }
+
+  *:not(input):not(textarea) {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  input,
+  textarea {
+    -webkit-user-select: text;
+    user-select: text;
+  }
 }
 
 // ============================================================================

--- a/src/view/content/MeritDemeritMention.tsx
+++ b/src/view/content/MeritDemeritMention.tsx
@@ -3,12 +3,17 @@
 import './MentionList.scss'
 import { Extension, mergeAttributes } from '@tiptap/core'
 import { Node } from '@tiptap/core'
-import { ReactRenderer } from '@tiptap/react'
+import { NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer, ReactRenderer } from '@tiptap/react'
 import Suggestion, { SuggestionKeyDownProps, SuggestionOptions, SuggestionProps } from '@tiptap/suggestion'
 import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react'
 import tippy, { Instance as TippyInstance } from 'tippy.js'
 import { motion } from 'framer-motion'
 import { PluginKey } from '@tiptap/pm/state'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 // Unique plugin key to avoid conflicts with other extensions
 const MeritDemeritPluginKey = new PluginKey('merit-demerit-suggestion')
@@ -161,12 +166,46 @@ MeritDemeritList.displayName = 'MeritDemeritList'
 // Merit/Demerit Node (for rendering inserted tags)
 // ============================================================================
 
+const MeritDemeritNodeView = ({ node, selected, editor, getPos }: NodeViewProps) => {
+  const isMerit = node.attrs['data-type'] === 'merit'
+  const circleColor = String(node.attrs['data-circle-color'] || (isMerit ? 'white' : 'black'))
+  const { mentionInteractionProps, handleMentionClick } =
+    useMentionNodeInteraction({ editor, getPos })
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      {...mentionInteractionProps}
+      className={withMentionInteractionClass(`merit-demerit-mention ${selected ? 'selected' : ''}`)}
+      data-node-type="meritDemerit"
+      data-id={node.attrs.id || undefined}
+      data-merit-type={String(node.attrs['data-type'] || '')}
+      data-circle-color={circleColor}
+      onClick={handleMentionClick}
+    >
+      <span
+        style={{
+          display: 'inline-block',
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          backgroundColor: circleColor,
+          border: '1.5px solid #333',
+          flexShrink: 0,
+        }}
+      />
+      <span>{node.attrs.label || ''}</span>
+    </NodeViewWrapper>
+  )
+}
+
 export const MeritDemeritNode = Node.create({
   name: 'meritDemerit',
   group: 'inline',
   inline: true,
   selectable: true,
   atom: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -187,7 +226,7 @@ export const MeritDemeritNode = Node.create({
     
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: 'merit-demerit-mention',
         'data-node-type': 'meritDemerit',
         'data-id': node.attrs.id,
@@ -206,7 +245,7 @@ export const MeritDemeritNode = Node.create({
           color: #111111;
           box-shadow: 0px 0.36px 1.8px -1.67px rgba(0, 0, 0, 0.23), 0px 1.37px 6.87px -3.33px rgba(0, 0, 0, 0.19);
         `,
-      }),
+      })),
       // Circle element
       [
         'span',
@@ -229,6 +268,10 @@ export const MeritDemeritNode = Node.create({
         node.attrs.label || '',
       ],
     ]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MeritDemeritNodeView)
   },
 })
 

--- a/src/view/content/MotivationsMention.tsx
+++ b/src/view/content/MotivationsMention.tsx
@@ -10,6 +10,11 @@ import React, { useCallback, useState, useRef, useEffect } from 'react'
 import { Node as ProseMirrorNode } from 'prosemirror-model'
 import { Editor } from '@tiptap/core'
 import { NodeSelection } from 'prosemirror-state'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 export interface MotivationsMentionAttributes {
   text: string
@@ -125,10 +130,14 @@ const MotivationsNodeView: React.FC<MotivationsNodeViewProps> = ({
     setEditValue(e.target.value)
   }, [])
 
+  const { mentionInteractionProps, handleMentionPointerDown } =
+    useMentionNodeInteraction({ editor, getPos })
+
   return (
     <NodeViewWrapper
       as="span"
-      className={`motivations-mention ${selected ? 'selected' : ''}`}
+      {...mentionInteractionProps}
+      className={withMentionInteractionClass(`motivations-mention ${selected ? 'selected' : ''}`)}
       data-motivation-id={motivationId ?? undefined}
     >
       <span className="motivations-emoji" contentEditable={false}>
@@ -145,6 +154,7 @@ const MotivationsNodeView: React.FC<MotivationsNodeViewProps> = ({
           onKeyDown={handleInputKeyDown}
           onBlur={handleInputBlur}
           placeholder="Your motivation here"
+          data-mention-interaction-ignore="true"
           onClick={(e) => e.stopPropagation()}
         />
       ) : (
@@ -156,7 +166,12 @@ const MotivationsNodeView: React.FC<MotivationsNodeViewProps> = ({
         </span>
       )}
 
-      <span className="motivations-grip" contentEditable={false} />
+      <span
+        className="motivations-grip"
+        contentEditable={false}
+        data-drag-handle
+        onPointerDown={handleMentionPointerDown}
+      />
     </NodeViewWrapper>
   )
 }
@@ -167,6 +182,7 @@ export const MotivationsMentionNode = Node.create({
   inline: true,
   atom: true,
   selectable: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -202,11 +218,11 @@ export const MotivationsMentionNode = Node.create({
 
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: 'motivations-mention',
         'data-type': 'motivations-mention',
         ...(motivationId ? { 'data-motivation-id': motivationId } : {}),
-      }),
+      })),
       `${MOTIVATION_EMOJI} ${text}`,
     ]
   },

--- a/src/view/content/PeopleMention.tsx
+++ b/src/view/content/PeopleMention.tsx
@@ -9,6 +9,11 @@ import React, { forwardRef, useEffect, useImperativeHandle, useState, useRef } f
 import tippy, { Instance as TippyInstance } from 'tippy.js'
 import { motion, AnimatePresence } from 'framer-motion'
 import { PluginKey } from '@tiptap/pm/state'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 const PeoplePluginKey = new PluginKey('people-suggestion')
 
@@ -124,7 +129,7 @@ const PeopleList = forwardRef<PeopleListRef, PeopleListProps>((props, ref) => {
 
 PeopleList.displayName = 'PeopleList'
 
-const PersonNodeView = ({ node, selected }: NodeViewProps) => {
+const PersonNodeView = ({ node, selected, editor, getPos }: NodeViewProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const tagRef = useRef<HTMLSpanElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
@@ -139,6 +144,7 @@ const PersonNodeView = ({ node, selected }: NodeViewProps) => {
   const label = attrs.label
   const name = attrs['data-name'] || label || 'Person'
   const initials = getPersonInitials(name)
+  const { mentionInteractionProps } = useMentionNodeInteraction({ editor, getPos })
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -189,13 +195,13 @@ const PersonNodeView = ({ node, selected }: NodeViewProps) => {
   return (
     <NodeViewWrapper as="span" style={{ display: 'inline', position: 'relative' }}>
       <span
+        {...mentionInteractionProps}
         ref={tagRef}
-        className={`person-mention ${selected ? 'selected' : ''}`}
+        className={withMentionInteractionClass(`person-mention ${selected ? 'selected' : ''}`)}
         data-person-id={attrs.id || undefined}
         data-person-label={label || undefined}
         data-person-name={attrs['data-name'] || undefined}
         onClick={handleClick}
-        style={{ cursor: 'pointer' }}
       >
         {label}
       </span>
@@ -334,6 +340,7 @@ export const PersonNode = Node.create({
   inline: true,
   selectable: true,
   atom: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -350,11 +357,11 @@ export const PersonNode = Node.create({
   renderHTML({ node, HTMLAttributes }) {
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: 'person-mention',
         'data-type': 'person',
         'data-id': node.attrs.id,
-      }),
+      })),
       node.attrs.label || '',
     ]
   },

--- a/src/view/content/QuestionMention.tsx
+++ b/src/view/content/QuestionMention.tsx
@@ -32,6 +32,11 @@ import { Node as ProseMirrorNode } from 'prosemirror-model'
 import { motion } from 'framer-motion'
 import { Editor } from '@tiptap/core'
 import { NodeSelection } from 'prosemirror-state'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 export interface QuestionMentionAttributes {
   checked: boolean
@@ -154,10 +159,14 @@ const QuestionNodeView: React.FC<QuestionNodeViewProps> = ({
     setEditValue(e.target.value)
   }, [])
 
+  const { mentionInteractionProps, handleMentionPointerDown } =
+    useMentionNodeInteraction({ editor, getPos })
+
   return (
     <NodeViewWrapper
       as="span"
-      className={`question-mention ${checked ? 'question-checked' : ''} ${selected ? 'selected' : ''}`}
+      {...mentionInteractionProps}
+      className={withMentionInteractionClass(`question-mention ${checked ? 'question-checked' : ''} ${selected ? 'selected' : ''}`)}
       data-question-id={questionId ?? undefined}
     >
       <motion.span
@@ -180,6 +189,7 @@ const QuestionNodeView: React.FC<QuestionNodeViewProps> = ({
           onKeyDown={handleInputKeyDown}
           onBlur={handleInputBlur}
           placeholder="Your question here"
+          data-mention-interaction-ignore="true"
           onClick={(e) => e.stopPropagation()}
         />
       ) : (
@@ -191,7 +201,12 @@ const QuestionNodeView: React.FC<QuestionNodeViewProps> = ({
         </span>
       )}
 
-      <span className="question-grip" contentEditable={false} />
+      <span
+        className="question-grip"
+        contentEditable={false}
+        data-drag-handle
+        onPointerDown={handleMentionPointerDown}
+      />
     </NodeViewWrapper>
   )
 }
@@ -202,6 +217,7 @@ export const QuestionMentionNode = Node.create({
   inline: true,
   atom: true,
   selectable: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -246,11 +262,11 @@ export const QuestionMentionNode = Node.create({
 
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: `question-mention ${checked ? 'question-checked' : ''}`,
         'data-type': 'question-mention',
         ...(questionId ? { 'data-question-id': questionId } : {}),
-      }),
+      })),
       `${icon} ${text}`,
     ]
   },

--- a/src/view/content/TimePointMention.tsx
+++ b/src/view/content/TimePointMention.tsx
@@ -16,6 +16,11 @@ import {
   readTimepointAuraFromAttrs,
   toAuraDataAttributes,
 } from '../aura/AuraModel'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 // Unique plugin key to avoid conflicts with other extensions
 const TimePointPluginKey = new PluginKey('timepoint-suggestion')
@@ -1796,36 +1801,28 @@ const TimePointNodeView = ({ node, selected, editor, getPos }: NodeViewProps) =>
   const isCurrentFocus = node.attrs.id === CURRENT_FOCUS_ID
   const aura = readTimepointAuraFromAttrs(node.attrs as Record<string, unknown>)
   const auraDataAttributes = aura ? toAuraDataAttributes(aura) : {}
-
-  const handleGripMouseDown = (e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    try {
-      const pos = getPos()
-      if (typeof pos !== 'number') return
-      editor.chain().focus().setNodeSelection(pos).run()
-    } catch {
-      // Ignore stale positions when the node is being removed.
-    }
-  }
+  const { mentionInteractionProps, handleMentionClick, handleMentionPointerDown } =
+    useMentionNodeInteraction({ editor, getPos })
 
   return (
     <NodeViewWrapper as="span" style={{ display: 'inline', position: 'relative' }}>
       <span
-        className={timepointClassName(isCurrentFocus, selected)}
+        {...mentionInteractionProps}
+        className={withMentionInteractionClass(timepointClassName(isCurrentFocus, selected))}
         data-type="timepoint"
         data-id={node.attrs.id || undefined}
         data-date={node.attrs['data-date'] || undefined}
         data-formatted={node.attrs['data-formatted'] || undefined}
         data-relative-label={node.attrs['data-relative-label'] || undefined}
         data-timepoint-kind={isCurrentFocus ? 'current-focus' : undefined}
+        onClick={handleMentionClick}
         {...auraDataAttributes}
       >
         <span
           className="location-grip"
           contentEditable={false}
           data-drag-handle
-          onMouseDown={handleGripMouseDown}
+          onPointerDown={handleMentionPointerDown}
           onClick={(e) => {
             e.preventDefault()
             e.stopPropagation()
@@ -1844,6 +1841,7 @@ export const TimePointNode = Node.create({
   inline: true,
   selectable: true,
   atom: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -1868,13 +1866,13 @@ export const TimePointNode = Node.create({
     const auraDataAttributes = aura ? toAuraDataAttributes(aura) : {}
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: timepointClassName(isCurrentFocus),
         'data-type': 'timepoint',
         'data-id': node.attrs.id,
         ...auraDataAttributes,
         ...(isCurrentFocus ? { 'data-timepoint-kind': 'current-focus' } : {}),
-      }),
+      })),
       ['span', { class: 'location-grip', contenteditable: 'false', 'data-drag-handle': '' }],
       node.attrs.label || '',
     ]

--- a/src/view/content/ToNotDoMention.tsx
+++ b/src/view/content/ToNotDoMention.tsx
@@ -32,6 +32,11 @@ import { Node as ProseMirrorNode } from 'prosemirror-model'
 import { motion } from 'framer-motion'
 import { Editor } from '@tiptap/core'
 import { NodeSelection } from 'prosemirror-state'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 export interface ToNotDoMentionAttributes {
   checked: boolean
@@ -154,20 +159,14 @@ const ToNotDoNodeView: React.FC<ToNotDoNodeViewProps> = ({
     setEditValue(e.target.value)
   }, [])
 
-  const handleGripMouseDown = useCallback(() => {
-    try {
-      const pos = getPos()
-      if (typeof pos !== 'number') return
-      editor.chain().focus().setNodeSelection(pos).run()
-    } catch {
-      // Ignore stale positions when the node is being removed.
-    }
-  }, [editor, getPos])
+  const { mentionInteractionProps, handleMentionPointerDown } =
+    useMentionNodeInteraction({ editor, getPos })
 
   return (
     <NodeViewWrapper
       as="span"
-      className={`to-not-do-mention ${checked ? 'to-not-do-checked' : ''} ${selected ? 'selected' : ''}`}
+      {...mentionInteractionProps}
+      className={withMentionInteractionClass(`to-not-do-mention ${checked ? 'to-not-do-checked' : ''} ${selected ? 'selected' : ''}`)}
       data-type="to-not-do-mention"
       data-checked={checked ? 'true' : 'false'}
       data-text={text}
@@ -177,7 +176,7 @@ const ToNotDoNodeView: React.FC<ToNotDoNodeViewProps> = ({
         className="todo-grip"
         contentEditable={false}
         data-drag-handle
-        onMouseDown={handleGripMouseDown}
+        onPointerDown={handleMentionPointerDown}
         title="Drag to move"
       />
 
@@ -201,6 +200,7 @@ const ToNotDoNodeView: React.FC<ToNotDoNodeViewProps> = ({
           onKeyDown={handleInputKeyDown}
           onBlur={handleInputBlur}
           placeholder="Your not-to-do here"
+          data-mention-interaction-ignore="true"
           onClick={(e) => e.stopPropagation()}
         />
       ) : (
@@ -269,11 +269,11 @@ export const ToNotDoMentionNode = Node.create({
 
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: `to-not-do-mention ${checked ? 'to-not-do-checked' : ''}`,
         'data-type': 'to-not-do-mention',
         ...(todoId ? { 'data-todo-id': todoId } : {}),
-      }),
+      })),
       `${checkboxChar} ${text}`,
     ]
   },

--- a/src/view/content/TodoMention.tsx
+++ b/src/view/content/TodoMention.tsx
@@ -56,6 +56,11 @@ import { Node as ProseMirrorNode } from 'prosemirror-model'
 import { motion } from 'framer-motion'
 import { Editor } from '@tiptap/core'
 import { NodeSelection } from 'prosemirror-state'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 // ============================================================================
 // Types
@@ -193,20 +198,14 @@ const TodoNodeView: React.FC<TodoNodeViewProps> = ({
     setEditValue(e.target.value)
   }, [])
 
-  const handleGripMouseDown = useCallback(() => {
-    try {
-      const pos = getPos()
-      if (typeof pos !== 'number') return
-      editor.chain().focus().setNodeSelection(pos).run()
-    } catch {
-      // Ignore stale positions when the node is being removed.
-    }
-  }, [editor, getPos])
+  const { mentionInteractionProps, handleMentionPointerDown } =
+    useMentionNodeInteraction({ editor, getPos })
 
   return (
     <NodeViewWrapper 
       as="span" 
-      className={`todo-mention ${checked ? 'todo-checked' : ''} ${selected ? 'selected' : ''}`}
+      {...mentionInteractionProps}
+      className={withMentionInteractionClass(`todo-mention ${checked ? 'todo-checked' : ''} ${selected ? 'selected' : ''}`)}
       data-type="todo-mention"
       data-checked={checked ? 'true' : 'false'}
       data-text={text}
@@ -217,7 +216,7 @@ const TodoNodeView: React.FC<TodoNodeViewProps> = ({
         className="todo-grip"
         contentEditable={false}
         data-drag-handle
-        onMouseDown={handleGripMouseDown}
+        onPointerDown={handleMentionPointerDown}
         title="Drag to move"
       />
 
@@ -243,6 +242,7 @@ const TodoNodeView: React.FC<TodoNodeViewProps> = ({
           onKeyDown={handleInputKeyDown}
           onBlur={handleInputBlur}
           placeholder="Your todo here"
+          data-mention-interaction-ignore="true"
           onClick={(e) => e.stopPropagation()}
         />
       ) : (
@@ -318,11 +318,11 @@ export const TodoMentionNode = Node.create({
     
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: `todo-mention ${checked ? 'todo-checked' : ''}`,
         'data-type': 'todo-mention',
         ...(todoId ? { 'data-todo-id': todoId } : {}),
-      }),
+      })),
       // Static HTML render: checkbox + text + grip placeholder
       `${checkboxChar} ${text}`,
     ]

--- a/src/view/content/VideoTimestampMention.tsx
+++ b/src/view/content/VideoTimestampMention.tsx
@@ -4,6 +4,11 @@ import './MentionList.scss'
 import React from 'react'
 import { Node, mergeAttributes } from '@tiptap/core'
 import { NodeViewProps, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
+import {
+  getMentionRenderAttributes,
+  useMentionNodeInteraction,
+  withMentionInteractionClass,
+} from './MentionInteraction'
 
 declare global {
   interface Window {
@@ -50,27 +55,13 @@ const postTimestampSeek = (seconds: number, label: string) => {
 const VideoTimestampNodeView = ({ node, selected, editor, getPos }: NodeViewProps) => {
   const seconds = readTimestampSeconds(node.attrs.seconds)
   const label = node.attrs.label || formatTimestampLabel(seconds)
+  const { mentionInteractionProps, selectNode } = useMentionNodeInteraction({ editor, getPos })
 
-  const selectTimestampNode = () => {
-    try {
-      const pos = getPos()
-      if (typeof pos !== 'number') return
-      editor.chain().focus().setNodeSelection(pos).run()
-    } catch {
-      // Ignore stale positions while the document is mutating.
-    }
-  }
-
-  const activate = (event: React.PointerEvent | React.KeyboardEvent) => {
+  const activate = (event: React.MouseEvent | React.KeyboardEvent) => {
     event.preventDefault()
     event.stopPropagation()
-    selectTimestampNode()
+    selectNode()
     postTimestampSeek(seconds, label)
-  }
-
-  const stopNativeSelection = (event: React.MouseEvent) => {
-    event.preventDefault()
-    event.stopPropagation()
   }
 
   return (
@@ -80,17 +71,18 @@ const VideoTimestampNodeView = ({ node, selected, editor, getPos }: NodeViewProp
       style={{ display: 'inline', position: 'relative' }}
     >
       <span
-        className={`duration-badge video-timestamp-mention ${selected ? 'selected' : ''}`.trim()}
+        {...mentionInteractionProps}
+        className={withMentionInteractionClass(
+          `duration-badge video-timestamp-mention ${selected ? 'selected' : ''}`.trim(),
+        )}
         data-type="video-timestamp"
         data-id={`video-timestamp:${seconds}`}
         data-video-timestamp-seconds={seconds}
         data-video-timestamp-label={label}
         role="button"
         tabIndex={0}
-        contentEditable={false}
         title={`Seek to ${label}`}
-        onPointerDown={activate}
-        onClick={stopNativeSelection}
+        onClick={activate}
         onKeyDown={(event) => {
           if (event.key === 'Enter' || event.key === ' ') {
             activate(event)
@@ -110,6 +102,7 @@ export const VideoTimestampNode = Node.create({
   inline: true,
   selectable: true,
   atom: true,
+  draggable: true,
 
   addAttributes() {
     return {
@@ -140,7 +133,7 @@ export const VideoTimestampNode = Node.create({
 
     return [
       'span',
-      mergeAttributes(HTMLAttributes, {
+      mergeAttributes(HTMLAttributes, getMentionRenderAttributes({
         class: 'duration-badge video-timestamp-mention',
         'data-type': 'video-timestamp',
         'data-id': `video-timestamp:${seconds}`,
@@ -148,7 +141,7 @@ export const VideoTimestampNode = Node.create({
         'data-video-timestamp-label': label,
         role: 'button',
         title: `Seek to ${label}`,
-      }),
+      })),
       ['span', { class: 'duration-badge-emoji video-timestamp-icon', 'aria-hidden': 'true' }, '▶'],
       ['span', { class: 'duration-badge-label' }, label],
     ]


### PR DESCRIPTION
## Summary

Generalizes Atlas mobile mention interaction so inline mention chips select as atomic TipTap nodes on touch instead of invoking native iOS text selection.

Related Notion issue: [#1613 Make focus tags draggable on touch devices](https://www.notion.so/36ac02931d09813abc92c421bd063442)

## What changed

- Added a shared `MentionInteraction` helper for draggable, non-editable atomic mention chips.
- Applied the shared behavior to timepoint, location, person, hashtag/focus, duration/video timestamp, todo, to-not-do, question, comment, motivation, merit/demerit, aura/finesse, and legacy mention renderers.
- Preserved mention-specific interactions such as editing child inputs, opening location/person popovers, and video timestamp seeking.
- Added focused regression coverage for draggable/non-editable focus hashtag render attributes.

## Validation

- `yarn test src/view/components/Aura.test.ts --run`
- `yarn ios:editor:build` from the Kairos repo against this Lifemap branch
- Physical-device Kairos Atlas build/install/relaunch on Kongwei’s iPhone
